### PR TITLE
Add Self-hosted WebAPI sample with .NET Framework

### DIFF
--- a/dfSelfHostWebAPI/.gitignore
+++ b/dfSelfHostWebAPI/.gitignore
@@ -1,0 +1,15 @@
+# ビルド出力
+bin/
+obj/
+
+# Visual Studioの一時ファイル
+.vs/
+*.user
+*.suo
+
+# NuGetパッケージ
+packages/
+
+# ローカル設定
+*.log
+*.tmp

--- a/dfSelfHostWebAPI/README.md
+++ b/dfSelfHostWebAPI/README.md
@@ -1,0 +1,53 @@
+# dfSelfHostWebAPI
+
+古いフレームワーク .NET Framework 4.6.2で実装されたセルフホスト型WebAPIのサンプルプロジェクトです。
+
+## 開発環境要件
+
+- Visual Studio 2022
+- .NET Framework 4.6.2 SDK
+  - VS2022をインストールする際に、個別のコンポーネントから「.NET Framework 4.6.2 開発ツール」を選択する必要がある
+  - または、Visual Studio インストーラーから後から追加
+
+## 特徴
+
+- **セルフホスト**: IISを必要とせず、実行ファイルとして動作するWebAPI
+- **.NET Framework 4.6.2**: 従来の.NET Frameworkを使用
+- **SimpleInjector**: 依存性注入（DI）コンテナとして採用
+- **Swagger**: APIドキュメント自動生成とテスト用UI
+- **SimpleInjector.Integration.WebApi**: NuGetから追加
+
+## 実行方法
+
+1. プロジェクトをビルド
+2. 実行ファイルを起動
+3. `http://localhost:9000` でサーバーが起動
+4. SwaggerUIは `http://localhost:9000/swagger` で確認可能
+   - Swaggerを表示するには、ブラウザで次のアドレスを開きます: `http://localhost:9000/swagger/`
+5. プログラムを実行するには、次のコマンドが必要です:
+   ```
+   netsh http add urlacl url=http://+:9000/ user=DOMAIN\ユーザー名
+   ```
+
+## エンドポイント
+
+- `GET /api/hello/{name}`
+  - 指定された名前に対して挨拶を返すサンプルAPI
+  - Swagger UIで各APIの詳細な説明を確認できます
+
+## 使用パッケージ
+
+- SimpleInjector 5.5.0
+- SimpleInjector.Integration.WebApi
+- Swashbuckle.Core 5.6.0
+- Microsoft.AspNet.WebApi.SelfHost 5.3.0
+
+## SwaggerのXML生成設定
+
+Swaggerでコメントを表示するために、以下の設定が必要：
+
+1. ソリューションエクスプローラーでプロジェクトを右クリック
+2. プロパティを選択
+3. ビルドタブで「XMLドキュメントファイルを生成」にチェックを入れる
+
+この設定により、ビルド時にXMLコメントファイルが生成され、Swaggerで表示されるようになります。

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI.sln
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36623.8 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dfSelfHostWebAPI", "dfSelfHostWebAPI\dfSelfHostWebAPI.csproj", "{EF5E9D84-A4DE-4ADA-B9CD-394E9FA52A63}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EF5E9D84-A4DE-4ADA-B9CD-394E9FA52A63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF5E9D84-A4DE-4ADA-B9CD-394E9FA52A63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF5E9D84-A4DE-4ADA-B9CD-394E9FA52A63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF5E9D84-A4DE-4ADA-B9CD-394E9FA52A63}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {37778E0D-ABE9-4F66-B2E4-465325D89A0E}
+	EndGlobalSection
+EndGlobal

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/App.config
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/App.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/Controllers/HelloController.cs
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/Controllers/HelloController.cs
@@ -1,0 +1,25 @@
+﻿using dfSelfHostWebAPI.Services;
+using System.Web.Http;
+using System.Web.Http.Description;
+
+namespace dfSelfHostWebAPI.Controllers
+{
+    /// <summary>
+    /// 挨拶を提供するAPI
+    /// </summary>
+    public class HelloController : ApiController
+    {
+        private readonly IMyService _service;
+
+        public HelloController( IMyService service ) => _service = service;
+
+        /// <summary>
+        /// 指定された名前に対して挨拶メッセージを返します
+        /// </summary>
+        /// <param name="name">挨拶する対象の名前</param>
+        /// <returns>挨拶メッセージ</returns>
+        [HttpGet, Route( "api/hello/{name}" )]
+        [ResponseType(typeof(string))]
+        public IHttpActionResult Get( string name ) => Ok( _service.Greet( name ) );
+    }
+}

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/Program.cs
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/Program.cs
@@ -1,0 +1,65 @@
+﻿using dfSelfHostWebAPI.Services;
+using SimpleInjector;
+using SimpleInjector.Integration.WebApi;
+using SimpleInjector.Lifestyles;
+using Swashbuckle.Application;
+using System;
+using System.IO;
+using System.Web.Http;
+using System.Web.Http.SelfHost;
+
+
+namespace dfSelfHostWebAPI
+{
+    internal class Program
+    {
+        private const int DefaultPort = 9000;
+
+        static void Main( string [] args )
+        {
+            var port = DefaultPort;
+            if (args.Length > 0 && int.TryParse(args[0], out int customPort))
+            {
+                port = customPort;
+            }
+
+            var baseUrl = $"http://localhost:{port}";
+            var config = new HttpSelfHostConfiguration(baseUrl);
+
+            // Web API ルート設定
+            config.MapHttpAttributeRoutes();
+
+            // Simple Injector 設定
+            var container = new Container();
+            container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            container.Register<IMyService, MyService>( Lifestyle.Scoped );
+            container.RegisterWebApiControllers( config );
+            container.Verify();
+
+            config.DependencyResolver = new SimpleInjectorWebApiDependencyResolver( container );
+
+            // Swagger 有効化
+            config.EnableSwagger( c => {
+                c.SingleApiVersion("v1", "SelfHost API");
+
+                // 実行時の出力フォルダ（通常は bin\Debug\...）にある XML コメントを読み込む
+                var xmlFile = $"{typeof(Program).Assembly.GetName().Name}.xml";
+                var xmlPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, xmlFile);
+                if (File.Exists(xmlPath))
+                {
+                    c.IncludeXmlComments(xmlPath);
+                }
+            } )
+            .EnableSwaggerUi();
+
+            // サーバ起動
+            using( var server = new HttpSelfHostServer( config ) )
+            {
+                server.OpenAsync().Wait();
+                Console.WriteLine( $"SelfHost running at {baseUrl}" );
+                Console.ReadLine();
+            }
+
+        }
+    }
+}

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/Properties/AssemblyInfo.cs
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般的な情報は、次の方法で制御されます。
+// 制御されます。アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更します。
+[assembly: AssemblyTitle( "dfSelfHostWebAPI" )]
+[assembly: AssemblyDescription( "" )]
+[assembly: AssemblyConfiguration( "" )]
+[assembly: AssemblyCompany( "" )]
+[assembly: AssemblyProduct( "dfSelfHostWebAPI" )]
+[assembly: AssemblyCopyright( "Copyright ©  2025" )]
+[assembly: AssemblyTrademark( "" )]
+[assembly: AssemblyCulture( "" )]
+
+// ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
+// 参照できなくなります。COM からこのアセンブリ内の型にアクセスする必要がある場合は、
+// その型の ComVisible 属性を true に設定します。
+[assembly: ComVisible( false )]
+
+// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
+[assembly: Guid( "ef5e9d84-a4de-4ada-b9cd-394e9fa52a63" )]
+
+// アセンブリのバージョン情報は次の 4 つの値で構成されています:
+//
+//      メジャー バージョン
+//      マイナー バージョン
+//      ビルド番号
+//      リビジョン
+//
+[assembly: AssemblyVersion( "1.0.0.0" )]
+[assembly: AssemblyFileVersion( "1.0.0.0" )]

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/Services/MyService.cs
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/Services/MyService.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dfSelfHostWebAPI.Services
+{
+    public interface IMyService
+    {
+        string Greet( string name );
+    }
+
+    public class MyService : IMyService
+    {
+        public string Greet( string name ) => $"Hello {name}, from SelfHost!";
+    }
+}

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/dfSelfHostWebAPI.csproj
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/dfSelfHostWebAPI.csproj
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EF5E9D84-A4DE-4ADA-B9CD-394E9FA52A63}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>dfSelfHostWebAPI</RootNamespace>
+    <AssemblyName>dfSelfHostWebAPI</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\dfSelfHostWebAPI.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.Bson.1.0.2\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleInjector, Version=5.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleInjector.5.5.0\lib\net461\SimpleInjector.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleInjector.Integration.WebApi, Version=5.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleInjector.Integration.WebApi.5.5.0\lib\net45\SimpleInjector.Integration.WebApi.dll</HintPath>
+    </Reference>
+    <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Swashbuckle.Core.5.6.0\lib\net40\Swashbuckle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.6.0.0\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.3.0\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.SelfHost, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.SelfHost.5.3.0\lib\net45\System.Web.Http.SelfHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.4.0.30506.0\lib\net40\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebActivatorEx.2.0\lib\net40\WebActivatorEx.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Controllers\HelloController.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\MyService.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+    <None Include="webapi.http" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/packages.config
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/packages.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="6.0.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.3.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.SelfHost" version="5.3.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="4.0.30506.0" targetFramework="net462" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net462" />
+  <package id="SimpleInjector" version="5.5.0" targetFramework="net462" />
+  <package id="SimpleInjector.Integration.WebApi" version="5.5.0" targetFramework="net462" />
+  <package id="Swashbuckle" version="5.6.0" targetFramework="net462" />
+  <package id="Swashbuckle.Core" version="5.6.0" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
+  <package id="WebActivatorEx" version="2.0" targetFramework="net462" />
+</packages>

--- a/dfSelfHostWebAPI/dfSelfHostWebAPI/webapi.http
+++ b/dfSelfHostWebAPI/dfSelfHostWebAPI/webapi.http
@@ -1,0 +1,4 @@
+@baseUrl=http://localhost:9000
+
+###
+GET {{baseUrl}}/api/hello/yourname


### PR DESCRIPTION
# 概要
.NET Framework を使用したSelf-hosted WebAPIのサンプルプロジェクトを追加

## 追加した機能
- Self-hosted WebAPIの基本実装
- HelloControllerの実装
- MyServiceの実装
- WebAPI用の設定
- HTTPリクエストのサンプル

## 動作確認方法
1. プロジェクトをビルド
2. アプリケーションを実行
3. webapi.httpファイルを使用してAPIをテスト

## 変更内容
以下のファイルを追加：
- `.gitignore`
- `README.md`
- `dfSelfHostWebAPI.sln`
- `dfSelfHostWebAPI/App.config`
- `dfSelfHostWebAPI/Controllers/HelloController.cs`
- `dfSelfHostWebAPI/Program.cs`
- `dfSelfHostWebAPI/Properties/AssemblyInfo.cs`
- `dfSelfHostWebAPI/Services/MyService.cs`
- `dfSelfHostWebAPI/dfSelfHostWebAPI.csproj`
- `dfSelfHostWebAPI/packages.config`
- `dfSelfHostWebAPI/webapi.http`